### PR TITLE
Fix dynamic_reconfigure dependency in CMake files

### DIFF
--- a/davis_ros_driver/CMakeLists.txt
+++ b/davis_ros_driver/CMakeLists.txt
@@ -63,12 +63,12 @@ add_library(davis_ros_driver_nodelet
 # they need to be build beforehand, especially the messages
 add_dependencies(davis_ros_driver
   ${catkin_EXPORTED_TARGETS}
-  ${PROJECT_NAME}_gencf
+  ${PROJECT_NAME}_gencfg
 )
 
 add_dependencies(davis_ros_driver_nodelet
   ${catkin_EXPORTED_TARGETS}
-  ${PROJECT_NAME}_gencf
+  ${PROJECT_NAME}_gencfg
 )
 
 # link the executable to the necesarry libs

--- a/dvs_ros_driver/CMakeLists.txt
+++ b/dvs_ros_driver/CMakeLists.txt
@@ -61,12 +61,12 @@ add_library(dvs_ros_driver_nodelet
 # they need to be build beforehand, especially the messages
 add_dependencies(dvs_ros_driver 
   ${catkin_EXPORTED_TARGETS} 
-  ${PROJECT_NAME}_gencf
+  ${PROJECT_NAME}_gencfg
 )
 
 add_dependencies(dvs_ros_driver_nodelet 
   ${catkin_EXPORTED_TARGETS} 
-  ${PROJECT_NAME}_gencf
+  ${PROJECT_NAME}_gencfg
 )
 
 # link the executable to the necesarry libs


### PR DESCRIPTION
${PROJECT_NAME}_gencfg was ${PROJECT_NAME}_gencf
This lead to dynamic reconfigure failing in some cases.
It had also triggered multiple CMake CMP0046 not-set warnings
(Error on non-existent dependency in add_dependencies.)