### PR TITLE
Remove redundant link target

### DIFF
--- a/dvs_ros_driver/CMakeLists.txt
+++ b/dvs_ros_driver/CMakeLists.txt
@@ -25,14 +25,12 @@ cs_add_library(dvs_ros_driver_nodelet
 target_link_libraries(dvs_ros_driver
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
-  ${CATKIN_DEVEL_PREFIX}/lib/libcaer${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
 
 # link the executable to the necesarry libs
 target_link_libraries(dvs_ros_driver_nodelet
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
-  ${CATKIN_DEVEL_PREFIX}/lib/libcaer${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
 
 # Install the nodelet library


### PR DESCRIPTION
I believe the explicit link target for libcaer in dvs_ros_driver is unnecessary because the libcaer_catkin package exports its own link target that should be captured in the `${catkin_LIBRARIES}` target. This change builds for me with both `catkin_make` and `catkin build`, but I do not have a DVS camera, so it still needs to be tested with actual hardware.