### PR TITLE
Fix/init and autoexposure

### DIFF
--- a/davis_ros_driver/cfg/DAVIS_ROS_Driver.cfg
+++ b/davis_ros_driver/cfg/DAVIS_ROS_Driver.cfg
@@ -14,7 +14,7 @@ gen.add("imu_enabled", bool_t, 0, "enables IMU", True)
 
 gen.add("autoexposure_enabled", bool_t, 0, "enables the RPG auto-exposure algorithm (experimental)", False)
 gen.add("autoexposure_gain", int_t, 0, "auto-exposure gain (lower: slow response time, without oscillations / higher: faster response time, with oscillations", 3, 1, 10)
-gen.add("autoexposure_desired_intensity", int_t, 0, "desired mean image intensity: controls the overall image brightness", 128, 0, 255)
+gen.add("autoexposure_desired_intensity", int_t, 0, "desired mean image intensity: controls the overall image brightness", 75, 0, 255)
 gen.add("exposure", int_t, 0, "exposure (frame exposure time in microseconds)", 5000, 0, 1000000)
 gen.add("frame_delay", int_t, 0, "frame_delay (delay between consecutive frames in microseconds)", 0, 0, 1000000)
 
@@ -62,7 +62,7 @@ addBias(grp_stage_two, "RefrBp",
 	"Maximum pixel firing rate (reset time before it can start to detect changes again)", 4, 25)
 
 grp_aps = gen.add_group("DAVIS_Biases_APS")
-addVdacBias(grp_aps, "ADC_RefHigh", "APS ADC upper conversion limit", 24, 7)
+addVdacBias(grp_aps, "ADC_RefHigh", "APS ADC upper conversion limit", 27, 7)
 addVdacBias(grp_aps, "ADC_RefLow", "APS ADC lower conversion limit", 1, 7)
 
 imu_acc_scale_enum = gen.enum([ gen.const("2g",         int_t, 0, "+/- 2 g"),

--- a/davis_ros_driver/include/davis_ros_driver/driver.h
+++ b/davis_ros_driver/include/davis_ros_driver/driver.h
@@ -60,7 +60,7 @@ private:
   void resetTimestamps();
   void caerConnect();
   int computeNewExposure(const std::vector<uint8_t>& img_data,
-                          const uint32_t current_exposure) const;
+                          const int32_t current_exposure) const;
 
   ros::NodeHandle nh_;
   ros::Publisher event_array_pub_;

--- a/davis_ros_driver/src/driver.cpp
+++ b/davis_ros_driver/src/driver.cpp
@@ -174,6 +174,13 @@ void DavisRosDriver::caerConnect()
   // No configuration is sent automatically!
   caerDeviceSendDefaultConfig(davis_handle_);
 
+  // In case autoexposure is enabled, initialize the exposure time with the exposure value
+  // from the parameter server
+  if(current_config_.autoexposure_enabled)
+  {
+    caerDeviceConfigSet(davis_handle_, DAVIS_CONFIG_APS, DAVIS_CONFIG_APS_EXPOSURE, current_config_.exposure);
+  }
+
   // Re-send params from param server if not first connection
   parameter_bias_update_required_ = true;
   parameter_update_required_ = true;

--- a/davis_ros_driver/src/driver.cpp
+++ b/davis_ros_driver/src/driver.cpp
@@ -188,7 +188,7 @@ void DavisRosDriver::caerConnect()
   readout_thread_ = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&DavisRosDriver::readout, this)));
 
   // wait for driver to be ready
-  ros::Duration(0.5).sleep();
+  ros::Duration(0.6).sleep();
 
   // initialize timestamps
   resetTimestamps();


### PR DESCRIPTION
This PR fixes a couple of small bugs:

* we now wait 0.6 s instead of 0.5 s for libcaer to be properly initialized (since libcaer internally waits for 0.5 s upon starting up, we add a safety margin of 0.1 s). This ensures that the timestamp reset is done properly, preventing too much offset between ros::Time::now() and the internal sensor clock.

* the dynamic reconfigure callback is registered BEFORE caerConnect() which enables to properly initialize current_config_ before any actual readout happens (https://answers.ros.org/question/28327/dynamic-reconfigure-default-parameters/). This suppresses garbage readout (frames with zero exposure, event generated by undefined biases, etc.) in the first few milliseconds of launching the driver.

* the autoexposure algorithm uses now the actual frame exposure time rather than the requested one. this does not seem to change the behavior of the autoexposure algorithm much but is more principled and might increase the speed of convergence.

* better default parameters at startup

@guillermogb ptal and merge