### PR TITLE
Fix compilation issues in and properly install/export package dvs_renderer

### DIFF
--- a/dvs_renderer/CMakeLists.txt
+++ b/dvs_renderer/CMakeLists.txt
@@ -23,20 +23,21 @@ cs_add_library(dvs_renderer_nodelet
   src/renderer.cpp
 )
 
-# link the executable to the necesarry libs
+# link the executable to the necessary libs
 target_link_libraries(dvs_renderer
-   ${catkin_LIBRARIES}
-   ${OpenCV_LIBRARIES}
+  ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 
 target_link_libraries(dvs_renderer_nodelet
-   ${catkin_LIBRARIES}
-   ${OpenCV_LIBRARIES}
+  ${catkin_LIBRARIES}
+  ${OpenCV_LIBRARIES}
 )
 
+# install the executable
 install(
-   TARGETS dvs_renderer
-   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  TARGETS dvs_renderer
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 # Install other support files for installation

--- a/dvs_renderer/CMakeLists.txt
+++ b/dvs_renderer/CMakeLists.txt
@@ -34,8 +34,6 @@ target_link_libraries(dvs_renderer_nodelet
    ${OpenCV_LIBRARIES}
 )
 
-cs_install()
-
 install(
    TARGETS dvs_renderer
    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -45,3 +43,6 @@ install(
 install(FILES dvs_renderer_nodelet.xml launch/nodelet_stereo.launch launch/nodelet_mono.launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
+
+cs_install()
+cs_export()

--- a/dvs_renderer/CMakeLists.txt
+++ b/dvs_renderer/CMakeLists.txt
@@ -37,6 +37,6 @@ target_link_libraries(dvs_renderer_nodelet
 cs_install()
 
 # Install other support files for installation
-install(FILES dvs_renderer_nodelet.xml nodelet_stereo.launch nodelet_mono.launch
+install(FILES dvs_renderer_nodelet.xml launch/nodelet_stereo.launch launch/nodelet_mono.launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/dvs_renderer/CMakeLists.txt
+++ b/dvs_renderer/CMakeLists.txt
@@ -36,6 +36,11 @@ target_link_libraries(dvs_renderer_nodelet
 
 cs_install()
 
+install(
+   TARGETS dvs_renderer
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 # Install other support files for installation
 install(FILES dvs_renderer_nodelet.xml launch/nodelet_stereo.launch launch/nodelet_mono.launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}


### PR DESCRIPTION
Contributions:
- Fix issue #61 (commit 777b703)
- Make package findable by e.g. `rospack` or launch-files (9631b8d)
- Install executable `dvs_renderer`, making it available for third-party projects (90da4dc)

Background for the last item is that we use a DVS simulation based on camera sensor frames in Gazebo. Hence, we would also like to render DVS events onto image frames. As of now, this is not possible because the API (in terms of launch files) do not allow for sufficient argument remapping.