### PR TITLE
Increase publish buffer for profits

### DIFF
--- a/davis_ros_driver/src/driver.cpp
+++ b/davis_ros_driver/src/driver.cpp
@@ -66,7 +66,7 @@ DavisRosDriver::DavisRosDriver(ros::NodeHandle & nh, ros::NodeHandle nh_private)
 
   event_array_pub_ = nh_.advertise<dvs_msgs::EventArray>(ns + "/events", 10);
   camera_info_pub_ = nh_.advertise<sensor_msgs::CameraInfo>(ns + "/camera_info", 1);
-  imu_pub_ = nh_.advertise<sensor_msgs::Imu>(ns + "/imu", 10);
+  imu_pub_ = nh_.advertise<sensor_msgs::Imu>(ns + "/imu", 1000);
   image_pub_ = nh_.advertise<sensor_msgs::Image>(ns + "/image_raw", 1);
   exposure_pub_ = nh_.advertise<std_msgs::Int32>(ns + "/exposure", 10);
 


### PR DESCRIPTION
Before:
![screenshot from 2018-10-11 21 32 54](https://user-images.githubusercontent.com/3010963/46830153-1c6a7380-cda0-11e8-81a5-4390bfc60425.png)
After:
![screenshot from 2018-10-11 21 39 07](https://user-images.githubusercontent.com/3010963/46830157-21c7be00-cda0-11e8-8eab-58f1047a5265.png)

I guess the unknown is whether the buffer will still eventually fill up...
Also, IMU messages are not perfectly regular, but at least the sequence ids are consecutive:
![screenshot from 2018-10-11 21 40 12](https://user-images.githubusercontent.com/3010963/46830338-9ef33300-cda0-11e8-811a-02849da09187.png)

@supitalp @guillermogb FYI