### PR TITLE
fixed compilation error - DVS128 device related information

### DIFF
--- a/davis_ros_driver/src/driver.cpp
+++ b/davis_ros_driver/src/driver.cpp
@@ -150,7 +150,7 @@ void DavisRosDriver::caerConnect()
 
   ROS_INFO("%s --- ID: %d, Master: %d, DVS X: %d, DVS Y: %d, Logic: %d.\n", davis_info_.deviceString,
            davis_info_.deviceID, davis_info_.deviceIsMaster, davis_info_.dvsSizeX, davis_info_.dvsSizeY,
-           davis_info_.logicVersion);
+           davis_info_.firmwareVersion);
 
   if (master_ && !davis_info_.deviceIsMaster)
   {

--- a/dvs_ros_driver/src/driver.cpp
+++ b/dvs_ros_driver/src/driver.cpp
@@ -46,7 +46,7 @@ DvsRosDriver::DvsRosDriver(ros::NodeHandle & nh, ros::NodeHandle nh_private) :
 
   ROS_INFO("%s --- ID: %d, Master: %d, DVS X: %d, DVS Y: %d, Logic: %d.\n", dvs128_info_.deviceString,
            dvs128_info_.deviceID, dvs128_info_.deviceIsMaster, dvs128_info_.dvsSizeX, dvs128_info_.dvsSizeY,
-           dvs128_info_.logicVersion);
+           dvs128_info_.firmwareVersion);
 
   current_config_.streaming_rate = 30;
   delta_ = boost::posix_time::microseconds(1e6/current_config_.streaming_rate);


### PR DESCRIPTION
src: fixed davis and dvs compilation error with checkout version of caer. logicVersion is renamed to firmwareVersion in libcaer.