### PR TITLE
Fix camera info publishing

### DIFF
--- a/davis_ros_driver/src/driver.cpp
+++ b/davis_ros_driver/src/driver.cpp
@@ -711,12 +711,6 @@ void DavisRosDriver::readout()
 
                         event_array_msg.reset();
                     }
-
-                    if (camera_info_manager_->isCalibrated())
-                    {
-                        sensor_msgs::CameraInfoPtr camera_info_msg(new sensor_msgs::CameraInfo(camera_info_manager_->getCameraInfo()));
-                        camera_info_pub_.publish(camera_info_msg);
-                    }
                 }
                 else if (type == IMU6_EVENT)
                 {
@@ -836,6 +830,13 @@ void DavisRosDriver::readout()
                         const int new_exposure = computeNewExposure(msg.data, current_exposure);
 
                         caerDeviceConfigSet(davis_handle_, DAVIS_CONFIG_APS, DAVIS_CONFIG_APS_EXPOSURE, new_exposure);
+                    }
+
+                    if (camera_info_manager_->isCalibrated())
+                    {
+                        sensor_msgs::CameraInfoPtr camera_info_msg(new sensor_msgs::CameraInfo(camera_info_manager_->getCameraInfo()));
+                        camera_info_msg->header.stamp = msg.header.stamp;
+                        camera_info_pub_.publish(camera_info_msg);
                     }
                 }
             }


### PR DESCRIPTION
This PR changes the publication of the camera info message. Instead of when an event is received, the message is now published whenever and APS frame is received. Also, the timestamp is now set properly.

This then allows using the camera calibration pipeline.