### PR TITLE
Fixed dvs_calibration code not compiling on Ubuntu 20.04 / ROS Noetic

### DIFF
--- a/dvs_calibration/src/camera_dvs_calibration.cpp
+++ b/dvs_calibration/src/camera_dvs_calibration.cpp
@@ -67,7 +67,7 @@ void CameraDvsCalibration::calibrate()
 
   // call stereo calibration
   cv::Mat R, T, E, F;
-  int flags = fix_intrinsics_ ? CV_CALIB_FIX_INTRINSIC : CV_CALIB_USE_INTRINSIC_GUESS;
+  int flags = fix_intrinsics_ ? cv::CALIB_FIX_INTRINSIC : cv::CALIB_USE_INTRINSIC_GUESS;
 
   cv::TermCriteria term_crit = cv::TermCriteria(cv::TermCriteria::COUNT + cv::TermCriteria::EPS, 30, 1e-6);
 #if CV_MAJOR_VERSION == 2
@@ -75,7 +75,7 @@ void CameraDvsCalibration::calibrate()
                                             camera_matrix_camera, dist_coeffs_camera, camera_matrix_dvs, dist_coeffs_dvs,
                                             cv::Size(standard_camera_info_.width, standard_camera_info_.height),
                                             R, T, E, F, term_crit, flags);
-#elif CV_MAJOR_VERSION == 3
+#elif CV_MAJOR_VERSION == 3 || CV_MAJOR_VERSION == 4
 double reproj_error = cv::stereoCalibrate(object_points_, image_points_camera_, image_points_dvs_,
                                           camera_matrix_camera, dist_coeffs_camera, camera_matrix_dvs, dist_coeffs_dvs,
                                           cv::Size(standard_camera_info_.width, standard_camera_info_.height),

--- a/dvs_calibration/src/mono_dvs_calibration.cpp
+++ b/dvs_calibration/src/mono_dvs_calibration.cpp
@@ -30,7 +30,7 @@ void MonoDvsCalibration::calibrate()
   cv::Mat cameraMatrix, distCoeffs;
   std::vector<cv::Mat> rvecs, tvecs;
   double reproj_error = cv::calibrateCamera(object_points_, image_points_, cv::Size(sensor_width_, sensor_height_),
-                                            cameraMatrix, distCoeffs, rvecs, tvecs, CV_CALIB_FIX_K3);
+                                            cameraMatrix, distCoeffs, rvecs, tvecs, cv::CALIB_FIX_K3);
 
   // update camera info
   new_camera_info_.height = sensor_height_;


### PR DESCRIPTION
ROS Noetic is bundled with OpenCV 4, meaning that some old C compatible constants (such as `CV_CALIB_FIX_INTRINSIC`) are not available anymore. This was leading the dvs_calibration package not to compile on Ubuntu 20.04 with ROS Noetic.

In order to fix the problem, these constants were therefore replaced by their C++ equivalent, which were also part of OpenCV 3.
An other modification also had to be done, to compile a part of the code that was restricted to OpenCV 2 and OpenCV 3.

The corrected code was compiled on ROS Kinetic (Ubuntu 16.04), ROS Melodic (Ubuntu 18.04) and ROS Noetic (Ubuntu 20.04) without any issue.